### PR TITLE
chore: add .impeccable to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .DS_Store
 .vscode/
+.impeccable/


### PR DESCRIPTION
Adds the `.impeccable/` directory to `.gitignore` to prevent the impeccable AI code review tool's cache/reports folder from being tracked in version control.